### PR TITLE
snap: disable tls support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -122,13 +122,11 @@ parts:
     source-branch: applied/ubuntu/noble-devel
     source-depth: 1
     build-packages:
-    - gnutls-dev
     - libdrm-dev
     - libgbm-dev
     - libturbojpeg0-dev
     - zlib1g-dev
     stage-packages:
-    - libgnutls30t64
     - libturbojpeg
     - zlib1g
 
@@ -174,6 +172,8 @@ parts:
     - pkg-config
     plugin: meson
     meson-parameters:
+    - -Dneatvnc:tls=disabled
+    - -Dneatvnc:nettle=disabled
     - -Dscreencopy-dmabuf=enabled
     - -Dneatvnc:h264=enabled
     override-build: |


### PR DESCRIPTION
Rather than telling it's unsupported.