### PR TITLE
snap: add support for username/password configuration

### DIFF
--- a/scripts/bin/ubuntu-frame-vnc
+++ b/scripts/bin/ubuntu-frame-vnc
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec ${SNAP}/usr/local/bin/wayvnc --gpu localhost 5900
+exec ${SNAP}/usr/local/bin/wayvnc --config ${SNAP_DATA}/wayvnc.config --gpu localhost 5900

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -13,8 +13,27 @@ else
 fi
 chmod 600 $config_file
 
-username="$(snapctl get username)"
-password="$(snapctl get password)"
+sanitized_get() {
+  key=$1
+  value="$(snapctl get "$key")"
+  sanitized="$( echo $value | tr -cd '\000-\177')"
+
+  if [ "$value" != "$sanitized" ]; then
+    echo "Bad \"$key\" value, only printable characters allowed" >&2
+    return 1
+  fi
+
+  if [ "${#value}" -gt 32 ]; then
+    echo "Bad \"$key\" value, maximum 32 characters allowed" >&2
+    return 2
+  fi
+
+  echo "$value"
+  return 0
+}
+
+username="$(sanitized_get username)" || exit 1 2>&1
+password="$(sanitized_get password)" || exit 2 2>&1
 
 # Ensure that either both username and password are set, or neither
 if [ -n "$username" ] && [ -n "$password" ] && [ "$password" != "$placeholder" ]; then
@@ -26,7 +45,7 @@ username=$username
 password=$password
 EOF
 
-elif [ -n "$username" ] && [ "$password" == "$placeholder" ]; then
+elif [ -n "$username" ] && [ "$password" == "$placeholder" ] && grep -q '^password=.\+' $config_file; then
   awk "
   BEGIN {
     print \"enable_auth=true\"
@@ -43,7 +62,7 @@ EOF
 else
   echo "Both 'username' and 'password' must be set to enable authentication,"
   echo "or both unset to disable it"
-  exit 1
+  exit 3
 fi
 
 # (Re)start the daemon if enabled and ocnfiguration changed

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,10 +1,57 @@
 #!/bin/bash
 set -euo pipefail
 
-# (Re)start the daemon
+config_file="$SNAP_DATA/wayvnc.config"
+save_file="$TMPDIR/wayvnc.config.save"
+placeholder="<enabled>"
+
+if [ -f $config_file ]; then
+  trap "rm --force $save_file" EXIT
+  cp --preserve=all $config_file $save_file
+else
+  touch $config_file
+fi
+chmod 600 $config_file
+
+username="$(snapctl get username)"
+password="$(snapctl get password)"
+
+# Ensure that either both username and password are set, or neither
+if [ -n "$username" ] && [ -n "$password" ] && [ "$password" != "$placeholder" ]; then
+  # Avoid leaking the password on 'snap get ubuntu-frame-vnc'
+  snapctl set password="$placeholder"
+  cat > $config_file <<EOF
+enable_auth=true
+username=$username
+password=$password
+EOF
+
+elif [ -n "$username" ] && [ "$password" == "$placeholder" ]; then
+  awk "
+  BEGIN {
+    print \"enable_auth=true\"
+    print \"username=$username\"
+  }
+  /^password=/ { print \$0 }
+  " $save_file > $config_file
+
+elif [ -z "$username" ] && [ -z "$password" ]; then
+  cat > $config_file <<EOF
+enable_auth=false
+EOF
+
+else
+  echo "Both 'username' and 'password' must be set to enable authentication,"
+  echo "or both unset to disable it"
+  exit 1
+fi
+
+# (Re)start the daemon if enabled and ocnfiguration changed
 if [ "$(snapctl get daemon)" = "true" ]; then
-  if snapctl services "$SNAP_INSTANCE_NAME.daemon" | grep -q inactive; then
-    snapctl start --enable "$SNAP_INSTANCE_NAME.daemon" 2>&1 || true
+  snapctl services "$SNAP_INSTANCE_NAME.daemon" | grep -q inactive && active=0 || active=1
+  snapctl start --enable "$SNAP_INSTANCE_NAME.daemon" 2>&1
+  if [ $active -eq 1 ] && ! cmp $config_file $save_file; then
+    snapctl restart "$SNAP_INSTANCE_NAME.daemon" 2>&1
   fi
 else
   snapctl stop --disable "$SNAP_INSTANCE_NAME.daemon" 2>&1 || true

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+snapctl set username=
+snapctl set password=

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -168,6 +168,7 @@ parts:
     - pkg-config
     plugin: meson
     meson-parameters:
+    - -Dneatvnc:tls=disabled
     - -Dscreencopy-dmabuf=enabled
     - -Dneatvnc:h264=enabled
     override-build: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -116,11 +116,13 @@ parts:
     source-branch: applied/ubuntu/noble-devel
     source-depth: 1
     build-packages:
+    - gnutls-dev
     - libdrm-dev
     - libgbm-dev
     - libturbojpeg0-dev
     - zlib1g-dev
     stage-packages:
+    - libgnutls30t64
     - libturbojpeg
     - zlib1g
 
@@ -166,8 +168,6 @@ parts:
     - pkg-config
     plugin: meson
     meson-parameters:
-    - -Dneatvnc:tls=disabled
-    - -Dneatvnc:nettle=disabled
     - -Dscreencopy-dmabuf=enabled
     - -Dneatvnc:h264=enabled
     override-build: |


### PR DESCRIPTION
```
sudo snap set ubuntu-frame-vnc username=foo password=bar
```

Enables username/password authentication on the VNC connection.

**NB**: Remmina doesn't support this mode (without encryption), but e.g. RealVNC does.